### PR TITLE
it can now read files delimited by tabs or spaces

### DIFF
--- a/weio/bladed_out_file.py
+++ b/weio/bladed_out_file.py
@@ -3,7 +3,7 @@ import os
 import numpy as np
 import re
 import pandas as pd
-
+import glob
 from .file import File, isBinary
 
 class BladedFile(File):
@@ -60,7 +60,7 @@ class BladedFile(File):
                 temp = []
                 temp_2 = []
         
-                temp =  t_line 
+                temp =  t_line[7:].strip() 
                 temp_2 = temp.split()
                 NDIMENS = int(temp_2[-1]);
             
@@ -71,20 +71,24 @@ class BladedFile(File):
                 temp = []
                 temp_2 = []
                 if NDIMENS == 3:
-                    temp =  t_line 
-                    temp_2 = str.split(temp,'\t')
-                    SensorNumber = int(temp_2[1])
-                    DataLength = int(temp_2[3])
+                    temp =  t_line[6:].strip()
+                    temp_2 = temp.split()
+                    #temp =  t_line   
+                    #temp_2 = str.split(temp,'\t')
+                    SensorNumber = int(temp_2[0])
+                    DataLength = int(temp_2[2])
                     
                     
                 elif NDIMENS == 2:
-                    temp =  t_line 
-                    temp_2 = str.split(temp,'\t')
-                    if len(temp_2) == 1:
-                        temp_2 = str.split(temp)
+                    #temp =  t_line 
+                    #temp_2 = str.split(temp,'\t')
+                    #if len(temp_2) == 1:
+                    #    temp_2 = str.split(temp)
                     
-                    SensorNumber = int(temp_2[1])
-                    DataLength = int(temp_2[2])  
+                    temp =  t_line[6:].strip()
+                    temp_2 = temp.split()
+                    SensorNumber = int(temp_2[0])
+                    DataLength = int(temp_2[1])  
                     NoOfSections = 1
                     SectionList = []
             
@@ -303,38 +307,39 @@ class BladedFile(File):
         Folder_out = []
         DataLength_file =[]
         jj = 0
-        for Folder, sub_folder, files in os.walk(pth):
-            for i in range(len(files)): 
-                if searchName in files[i]:
+        files = glob.glob(os.path.join(pth, searchName+'*') )
+        
+        for i in range(len(files)): 
+            if searchName in files[i]:
+                
+                jj +=1 # check if it is the first file
+                files_out.append(files[i])
+                Folder_out.append(pth)    
+                
+                
+                # Call "Read_bladed_file" function to Read and store data:
+                self.DataValue(pth, files[i])    
+                
+                # gather all channel files together:
+                if jj == 1: # for the 1st index, create a variable with file name
                     
-                    jj +=1 # check if it is the first file
-                    files_out.append(files[i])
-                    Folder_out.append(Folder)    
-                    
-                    
-                    # Call "Read_bladed_file" function to Read and store data:
-                    self.DataValue(Folder, files[i])    
-                    
-                    # gather all channel files together:
-                    if jj == 1: # for the 1st index, create a variable with file name
-                        
-                        # name = files_out[0][:-4]
-                        self.BL_Data = self.DataOut
-                        self.BL_SensorNames = self.SensorName
-                        self.BL_SensorUnits = self.SensorUnit
-                        DataLength_file.append(self.Data_Length_out)
-                    else: # append the rest, but in axis=1
-                        # name = files_out[0][:-4]
-                        # skip the file if data length (dimension) is different with the rest:
-                        if DataLength_file[0] == self.Data_Length_out: 
-                            self.BL_Data =  np.append(self.BL_Data, self.DataOut, axis=1)
-                            for ind_s in range(len(self.SensorName)):
-                                self.BL_SensorNames.append(self.SensorName[ind_s])
-                                self.BL_SensorUnits.append(self.SensorUnit[ind_s])
-            
-            self.BL_ChannelUnit =[]
-            for jjj, name_unit in enumerate(self.BL_SensorNames):
-                self.BL_ChannelUnit.append(self.BL_SensorNames[jjj] + '[' + self.BL_SensorUnits[jjj] + ']')
+                    # name = files_out[0][:-4]
+                    self.BL_Data = self.DataOut
+                    self.BL_SensorNames = self.SensorName
+                    self.BL_SensorUnits = self.SensorUnit
+                    DataLength_file.append(self.Data_Length_out)
+                else: # append the rest, but in axis=1
+                    # name = files_out[0][:-4]
+                    # skip the file if data length (dimension) is different with the rest:
+                    if DataLength_file[0] == self.Data_Length_out: 
+                        self.BL_Data =  np.append(self.BL_Data, self.DataOut, axis=1)
+                        for ind_s in range(len(self.SensorName)):
+                            self.BL_SensorNames.append(self.SensorName[ind_s])
+                            self.BL_SensorUnits.append(self.SensorUnit[ind_s])
+        
+        self.BL_ChannelUnit =[]
+        for jjj, name_unit in enumerate(self.BL_SensorNames):
+            self.BL_ChannelUnit.append(self.BL_SensorNames[jjj] + '[' + self.BL_SensorUnits[jjj] + ']')
             
             ## outputs are:
             ## self.BL_Data

--- a/weio/bladed_out_file.py
+++ b/weio/bladed_out_file.py
@@ -80,6 +80,9 @@ class BladedFile(File):
                 elif NDIMENS == 2:
                     temp =  t_line 
                     temp_2 = str.split(temp,'\t')
+                    if len(temp_2) == 1:
+                        temp_2 = str.split(temp)
+                    
                     SensorNumber = int(temp_2[1])
                     DataLength = int(temp_2[2])  
                     NoOfSections = 1
@@ -114,7 +117,8 @@ class BladedFile(File):
                 # print(t_line)
                 temp = t_line
                 temp_2 = str.split(temp,'\' \'')
-                SectionList = np.array(temp_2[1:], dtype=str)
+                temp_2[0] = temp_2[0].replace('AXITICK\t','')
+                SectionList = np.array(temp_2[:], dtype=str)
                 NoOfSections = len(SectionList)
             
             # Here you can find channel names:    
@@ -122,12 +126,16 @@ class BladedFile(File):
                 # print(t_line)
                 temp = t_line.split('\t')
                 if len(temp) == 1:
-                    temp = t_line.split()
-                name_tmp = temp[1]
+                    temp = t_line.split('   ') # use 3 space instead of TAB
+                try:    
+                    name_tmp = temp[1]
+                except:
+                    name_tmp = temp[0]
+                    
                 name_tmp_2 = name_tmp.split('\'')
                 name_tmp_3 = []
                 for j in range(len(name_tmp_2)):
-                    if name_tmp_2[j] != ' ' and name_tmp_2[j] != '' and name_tmp_2[j] != '\n':
+                    if name_tmp_2[j] != ' ' and name_tmp_2[j] != '' and name_tmp_2[j] != '\n' and name_tmp_2[j] != 'VARIAB ':
                         # print( name_tmp_2[j])
                         name_tmp_3.append(name_tmp_2[j]) 
                 
@@ -136,10 +144,13 @@ class BladedFile(File):
                 
             # Here you can find channel units:         
             if re.search('VARUNIT', t_line):
-                temp = t_line.split('\t')
-                name_tmp = temp[1]
-                name_tmp_2 = name_tmp.split(' ')
-                name_tmp_2[-1] = name_tmp_2[-1].replace('\n','')
+                # temp = t_line.split('\t')
+                # if len(temp)<2:
+                temp = t_line.split()
+                name_tmp_2 = temp[1:]
+                # name_tmp = temp[1]
+                # name_tmp_2 = name_tmp.split(' ')
+                # name_tmp_2[-1] = name_tmp_2[-1].replace('\n','')
                 name_tmp_4 = name_tmp_2
                 for j in range(len(name_tmp_2)):
                     ## rename stupid unit's names of Bladed to SI unit's name
@@ -230,24 +241,38 @@ class BladedFile(File):
         else:
             # print('it is ascii')
             if NDIMENS == 2:
-               tmp_3 = np.loadtxt(filename) 
-               data_tmp = np.reshape(tmp_3,(SensorNumber, DataLength), order='F')
+                try:
+                    tmp_3 = np.loadtxt(filename) 
+                    data_tmp = np.transpose(tmp_3)#np.reshape(tmp_3,(SensorNumber, DataLength), order='F')
+                except:
+                    ####  I am getting tired of bladed, so just leave it empty if it is not possible to read it.
+                    data_tmp = np.empty((SensorNumber, DataLength)) * np.nan
+
+                    # data_tmp =[] #
            
             if NDIMENS == 3:
-                tmp_3 = np.loadtxt(filename) 
-
-
-                temp_4 = np.zeros([SensorNumber,NoOfSections,DataLength])
-            
+                try:
+                    tmp_3 = np.loadtxt(filename) 
+                    #print(file_in)
+                    
                 
-                
-                ## Bladed ascii file is written so stupid when matrix is 3 dimensional: 
-                for nsec in range(NoOfSections):
-                    dd_new = 0
-                    for dd in range(nsec,int(tmp_3.shape[0]),NoOfSections):
-                        temp_4[:,nsec,dd_new] = tmp_3[dd,:]
-                        dd_new += 1
-                data_tmp = np.reshape(temp_4,(SensorNumber, NoOfSections, DataLength), order='F')            
+                    temp_4 = np.zeros([SensorNumber,NoOfSections,DataLength])
+                    
+                     
+                    
+                    ## Bladed ascii file is written so stupid when matrix is 3 dimensional: 
+                    for nsec in range(NoOfSections):
+                        # print('nsec',nsec)
+                        dd_new = 0
+                        for dd in range(nsec,int(tmp_3.shape[0]),NoOfSections): #enumerate(np.arange(nsec,int(tmp_3.shape[0]),NoOfSections)):
+                            # print('dd',dd)
+                            # print(dd_new)
+                            temp_4[:,nsec,dd_new] = tmp_3[dd,:]
+                            dd_new += 1 # it should go up to "DataLength"
+                    data_tmp = np.reshape(temp_4,(SensorNumber, NoOfSections, DataLength), order='F') 
+                    
+                except:
+                    data_tmp = np.empty((SensorNumber, NoOfSections, DataLength)) * np.nan
         
         self.OrgData(DataLength,SectionList,ChannelName,data_tmp,NDIMENS,ChannelUnit)
 
@@ -261,12 +286,19 @@ class BladedFile(File):
     def _read(self):
         filename_0 = self.filename
         filename_1 = filename_0.replace('\\' , '/')
-        filename_2 = filename_1.split('/')
-        pth = self.filename.replace(filename_2[-1],'') # remove file name
-        keep_filename = filename_2[-1][:-4]
+        filename_2 = os.path.splitext(filename_1)
+        
+        pth = os.path.dirname(filename_1)
+        # pth = self.filename.replace(filename_2[-1],'') # remove file name
+        
+        filename_3 = filename_2[0].split('/')
+        
+        keep_filename = filename_3[-1]
+              
         # keep_filename = filename_2[-1].replace('.$PJ','')
         searchName = keep_filename + '.%'
-        pth = pth[:-1] #  keep only the path
+        
+        # pth = pth[:-1] #  keep only the path
         files_out = [] 
         Folder_out = []
         DataLength_file =[]

--- a/weio/tests/test_bladed.py
+++ b/weio/tests/test_bladed.py
@@ -21,12 +21,17 @@ class Test(unittest.TestCase):
     
 
     def test_Bladed(self):
+        ## check for binary
         F = weio.read(os.path.join(MyDir,'Bladed_out_binary.$41')) 
         #F = BladedFile(os.path.join(MyDir,'Bladed_out_binary.$41'))
         DF = F.toDataFrame()
         self.assertAlmostEqual(DF['0.0m-Blade 1 Fx (Root axes)[0.0m-N]'].values[0],146245.984375)
 
+        ## check for ASCII
         F = weio.read(os.path.join(MyDir,'Bladed_out_ascii.$41'))
+        DF = F.toDataFrame()
+        self.assertAlmostEqual(DF['0.0m-Blade 1 Fx (Root axes)[0.0m-N]'].values[0]==146363.8)
+
         # TODO TODO check that ascii works fine
 
 


### PR DESCRIPTION
Hi Emmanuel,
I have made some changes in the code. As you mentioned before, I use `glob `instead of `walk` to avoid the code going through subfolders. I also fixed those problem with delimiters so it can read both Tab and space. Hopefully, it works for all different bladed outputs.
I add a check to the unittest for ascii file too. Please have a look and let me know if it is good enough.

Thanks.
