### PR TITLE
Update __init__.py

### DIFF
--- a/weio/__init__.py
+++ b/weio/__init__.py
@@ -34,11 +34,11 @@ def fileFormats():
     from .vtk_file import VTKFile
     from .bladed_out_file         import BladedFile
     formats = []
+    formats.append(FileFormat(FASTInputFile))
     formats.append(FileFormat(CSVFile))
     formats.append(FileFormat(TecplotFile))
     formats.append(FileFormat(ExcelFile))
     formats.append(FileFormat(BladedFile))
-    formats.append(FileFormat(FASTInputFile))
     formats.append(FileFormat(FASTOutputFile))
     formats.append(FileFormat(FASTWndFile))
     formats.append(FileFormat(FASTLinearizationFile))


### PR DESCRIPTION
Salut, 

Change formats appending order. Start with FASTInputFile. It is a quick fix to avoid loading Airfoils coordinate files as CSV (e.g the ones from the 15MW IEA Wind Turbine). 

NB: 
1. the Airfoils coordinate files are not loaded as CSV when one of the comment line (2, 3, 4, 6, 7, 8) has more than 11 fields (like the file that is used when running the make command)
2.If it is not possible to change the appending order this could also be fixed using a if statement right before the pd.read_csv line from the csv_file.py (line 222), to check if the 2nd field of the coordinate file is 'NumCoords' .
 
It is likely that a better fix exists! :)

A+

Matt